### PR TITLE
Add support for dev and beta channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 script:
-  - asdf plugin-test dart $TRAVIS_BUILD_DIR 'dart --version'
+  - asdf plugin test dart . --asdf-plugin-gitref $TRAVIS_COMMIT 'dart --version'
 
 before_script:
   - git clone https://github.com/asdf-vm/asdf.git

--- a/bin/install
+++ b/bin/install
@@ -53,22 +53,32 @@ install_dart () {
     local tempdir=$(my_mktemp $platform)
     local allow_extras=0
     local major_version=$(echo $version | cut -d "." -f1)
+    # supported channels are "stable", "beta" and "dev"
+    local channel="stable"
 
-    echo "$install_type"
-    echo "$version"
-    echo "$install_path"
-    echo "$platform"
-    echo "$arch"
-    echo "$tempdir"
-    echo "$allow_extras"
-    echo "$major_version"
+    echo "Version: $version"
+    echo "Install Path: $install_path"
+    echo "Platform: $platform"
+    echo "Architecture: $arch"
+    echo "Downloading to temp directory $tempdir"
+    echo "Include Extras: $allow_extras"
+    echo "Major Dart Version: $major_version"
 
     if [ $major_version -lt "2" ]; then
         allow_extras=1
     fi
 
+    # Check if this is a beta version
+    if [ "${version: -5}" == ".beta" ]; then
+        channel="beta"
+    fi
+    # Check if this is a dev version
+    if [[ $version == *"dev"* ]]; then
+        channel="dev"
+    fi
+
     # install the sdk
-    URL="https://storage.googleapis.com/dart-archive/channels/stable/release/${version}/sdk/dartsdk-${platform}-${arch}-release.zip"
+    URL="https://storage.googleapis.com/dart-archive/channels/${channel}/release/${version}/sdk/dartsdk-${platform}-${arch}-release.zip"
     echo "Installing Dart SDK..."
     echo $URL
     curl $URL -o "${tempdir}/sdk.zip"

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,11 +2,26 @@
 set -eu
 
 BASE_URL="https://www.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/"
+BETA_URL="https://www.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/beta/release/&delimiter=/"
+DEV_URL="https://www.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/dev/release/&delimiter=/"
 
-VERSIONS=$(curl --silent $BASE_URL \
+BASE_VERSIONS=$(curl --silent $BASE_URL \
     | grep "channels/stable/release/[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*" \
     | rev \
     | cut -d "/" -f2 \
     | rev)
+
+BETA_VERSIONS=$(curl --silent $BETA_URL \
+    | grep "channels/beta/release/.*\.beta" \
+    | rev \
+    | cut -d "/" -f2 \
+    | rev)
+
+DEV_VERSIONS=$(curl --silent $DEV_URL \
+    | grep "channels/dev/release/.*dev.*" \
+    | rev \
+    | cut -d "/" -f2 \
+    | rev)
+VERSIONS=$(echo $DEV_VERSIONS $BETA_VERSIONS $BASE_VERSIONS | sort)
 
 echo $VERSIONS


### PR DESCRIPTION
## Problem
This plugin doesn't support the dev and beta channels.

## Solution
Add support for those channels
This should resolve #7 .

FYI @niku are you available to clone this branch and make sure fits your needs. I believe there are some older versions that are being filtered out that didn't match the current naming scheme for these channels but I can probably add these if necessary.
This can be done by going into `~/.asdf/plugins/dart` and checking out this branch and then installing the version as you normally would. If not I'll probably merge this on Monday since this seems to work for me.