### PR TITLE
Add support for 7z

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ dart plugin for [asdf version manager](https://github.com/asdf-vm/asdf)
 
 ## Requirements
 - `curl`
-- `unzip` (apt-get install unzip)
+- `unzip` or `7z` to decompress the downloaded zip
 
 
 ## Install
@@ -15,7 +15,7 @@ asdf plugin-add dart https://github.com/patoconnor43/asdf-dart.git
 
 ## Use
 
-Check the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of dart.
+Check the [asdf](https://github.com/asdf-vm/asdf) README for instructions on how to install & manage versions of dart.
 
 ## Installation differences between Dart 1 and Dart 2
 
@@ -32,15 +32,14 @@ This means you can point your IDE at `${HOME}/.asdf_dart_sdk` and anytime you ch
 will point to the most recent version. If you're interested check the [install instructions](./tools/README.md)
 inside the `tools/` directory.
 
-## Known Issues
-
-Occasionally when switching between Dart 1 and Dart 2, the `dartium` and `content_shell` shims can break. When trying to use them they'll report `No such command in <version> of dart`. To fix this, you can delete the `dartium` and `content_shell` shims from `$HOME/.asdf/shims` and then recreate the shims by running `asdf reshim dart <version>`.
-
 ## Included Shims
 
-- `dart`
 - `dart2js`
+- `dart2native`
+- `dart`
 - `dartanalyzer`
+- `dartaotruntime`
+- `dartdevc`
 - `dartdevc`
 - `dartdoc`
 - `dartfmt`

--- a/bin/install
+++ b/bin/install
@@ -32,7 +32,7 @@ get_arch () {
         i686|i386) arch="ia32"; ;;
         *)
             echo "Arch '$(uname -m)' not supported!" >&2
-            exit 1
+            exit 2
             ;;
     esac
 
@@ -42,6 +42,14 @@ get_arch () {
 my_mktemp () {
     local tempdir=$(mktemp -d asdf-dart.XXXX)
     echo -n $tempdir
+}
+
+validate_unzip () {
+    if ! command -v unzip &> /dev/null && ! command -v 7z &> /dev/null
+    then
+        echo "Missing zip decompresser. This plugin relies on either 7z or unzip."
+        exit 3
+    fi
 }
 
 install_dart () {
@@ -63,6 +71,7 @@ install_dart () {
     echo "Downloading to temp directory $tempdir"
     echo "Include Extras: $allow_extras"
     echo "Major Dart Version: $major_version"
+    validate_unzip
 
     if [ $major_version -lt "2" ]; then
         allow_extras=1
@@ -98,7 +107,13 @@ install_dart () {
     fi
 
     echo "Unzipping Dart SDK to $install_path..."
-    unzip -d "$install_path" "$tempdir/sdk.zip" > /dev/null 2>&1
+    if command -v unzip &> /dev/null
+    then
+        unzip -d "$install_path" "$tempdir/sdk.zip" > /dev/null 2>&1
+    else
+        7z x "$tempdir/sdk.zip" -o"$install_path" > /dev/null 2>&1
+    fi
+
     if [ $allow_extras -eq "1" ]; then
         echo "Unzipping Content Shell to $install_path..."
         unzip -d "$install_path" "$tempdir/content_shell.zip" > /dev/null 2>&1


### PR DESCRIPTION
Related to #9 .

It was suggested to add support for 7z as an option as well as unzip. This PR also added validation so the zip isn't downloaded unless there is a tool to decompress it.

FYI @watzon