### PR TITLE
Add better version sorting and allow the beta and dev channel to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ asdf plugin-add dart https://github.com/patoconnor43/asdf-dart.git
 
 Check the [asdf](https://github.com/asdf-vm/asdf) README for instructions on how to install & manage versions of dart.
 
+## Customization
+The Dart team releases a lot of beta and dev versions publicly for people to try
+out. This can be frustrating if you're just trying to install the latest dart
+version though. If you would like to prevent fetching versions from these
+channels, you can set:
+```
+ASDF_DART_ENABLE_BETA=false
+ASDF_DART_ENABLE_DEV=false
+```
+These environment variables will ensure only the base versions are included.
+
 ## Installation differences between Dart 1 and Dart 2
 
 All Dart 1 versions come with corresponding versions of `content_shell` and `dartium`. Since Dart 2 doesn't use these tools, they aren't included. For more information on tooling differences, check out [the docs](https://webdev.dartlang.org/dart-2).
@@ -44,6 +55,7 @@ inside the `tools/` directory.
 - `dartdoc`
 - `dartfmt`
 - `pub`
+- `and many more...`
 - `content_shell` (Dart 1 exclusive)
 - `dartium` (Dart 1 exclusive)
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,23 +5,33 @@ BASE_URL="https://www.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels
 BETA_URL="https://www.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/beta/release/&delimiter=/"
 DEV_URL="https://www.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/dev/release/&delimiter=/"
 
+BETA_VERSIONS=""
+DEV_VERSIONS=""
+
 BASE_VERSIONS=$(curl --silent $BASE_URL \
     | grep "channels/stable/release/[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*" \
     | rev \
     | cut -d "/" -f2 \
     | rev)
 
-BETA_VERSIONS=$(curl --silent $BETA_URL \
-    | grep "channels/beta/release/.*\.beta" \
-    | rev \
-    | cut -d "/" -f2 \
-    | rev)
+if [ "${ASDF_DART_ENABLE_BETA:-true}" == "true" ]; then
+    BETA_VERSIONS=$(curl --silent $BETA_URL \
+        | grep "channels/beta/release/.*\.beta" \
+        | rev \
+        | cut -d "/" -f2 \
+        | rev)
+fi
 
-DEV_VERSIONS=$(curl --silent $DEV_URL \
-    | grep "channels/dev/release/.*dev.*" \
-    | rev \
-    | cut -d "/" -f2 \
-    | rev)
-VERSIONS=$(echo $DEV_VERSIONS $BETA_VERSIONS $BASE_VERSIONS | sort)
+if [ "${ASDF_DART_ENABLE_DEV:-true}" == "true" ]; then
+    DEV_VERSIONS=$(curl --silent $DEV_URL \
+        | grep "channels/dev/release/.*dev.*" \
+        | rev \
+        | cut -d "/" -f2 \
+        | rev)
+fi
+
+# Pipe the versions through tr to get proper version sorting, otherwise the echoed
+# variables will all appear on a single line.
+VERSIONS=$(echo $DEV_VERSIONS $BETA_VERSIONS $BASE_VERSIONS | tr " " '\n' | sort -V)
 
 echo $VERSIONS


### PR DESCRIPTION
The version sorting was broken because it turns out echoing a variable separates by space rather than preserving the newline. This meant that the sorting I was doing at the end wasn't doing anything at all since all the versions appeared on a single line. I fixed that by running them through `tr` first.

I also added the ability to ignore dev and beta channels because it's nice to have the option but _most_ people probably don't need that option. You have to opt-in to ignoring them though with the documented env vars.

closes #11 