### PR TITLE
Remove dev and beta channels from default version listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ asdf plugin-add dart https://github.com/patoconnor43/asdf-dart.git
 Check the [asdf](https://github.com/asdf-vm/asdf) README for instructions on how to install & manage versions of dart.
 
 ## Customization
-The Dart team releases a lot of beta and dev versions publicly for people to try
-out. This can be frustrating if you're just trying to install the latest dart
-version though. If you would like to prevent fetching versions from these
-channels, you can set:
+The default behavior for this plugin used to include `dev` and `beta` versions
+when listing all the versions. This got really noisy and interfered with 
+`asdf install dart latest` installing the latest stable version. If you want
+to re-enable these channels you can set these environment variables.
 ```
-ASDF_DART_ENABLE_BETA=false
-ASDF_DART_ENABLE_DEV=false
+ASDF_DART_ENABLE_BETA=true
+ASDF_DART_ENABLE_DEV=true
 ```
 These environment variables will ensure only the base versions are included.
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -14,7 +14,7 @@ BASE_VERSIONS=$(curl --silent $BASE_URL \
     | cut -d "/" -f2 \
     | rev)
 
-if [ "${ASDF_DART_ENABLE_BETA:-true}" == "true" ]; then
+if [ "${ASDF_DART_ENABLE_BETA:-false}" == "true" ]; then
     BETA_VERSIONS=$(curl --silent $BETA_URL \
         | grep "channels/beta/release/.*\.beta" \
         | rev \
@@ -22,7 +22,7 @@ if [ "${ASDF_DART_ENABLE_BETA:-true}" == "true" ]; then
         | rev)
 fi
 
-if [ "${ASDF_DART_ENABLE_DEV:-true}" == "true" ]; then
+if [ "${ASDF_DART_ENABLE_DEV:-false}" == "true" ]; then
     DEV_VERSIONS=$(curl --silent $DEV_URL \
         | grep "channels/dev/release/.*dev.*" \
         | rev \


### PR DESCRIPTION
When initially adding support for the `dev` and `beta` channels I didn't consider the implications that would have on `asdf install dart latest`. Before this PR, that would almost always install a beta or dev release because those happen so frequently. Most people using this plugin _probably_ just want to install stable releases of dart and including these other channels seriously clutters `asdf list-all dart`. 

This PR will hide those by assuming the default value of `ASDF_DART_ENABLE_BETA` and `ASDF_DART_ENABLE_DEV` is `false` If you want to re-enable those versions just change the environment variables:
```
ASDF_DART_ENABLE_BETA=true
ASDF_DART_ENABLE_DEV=true
```
Also, feel free to let me know if these assumptions are incorrect :wink: 