### PR TITLE
Add support for apple arm64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,7 @@ get_arch () {
     local arch=""
 
     case "$(uname -m)" in
-        x86_64|amd64) arch="x64"; ;;
+        x86_64|amd64|arm64) arch="x64"; ;;
         i686|i386) arch="ia32"; ;;
         *)
             echo "Arch '$(uname -m)' not supported!" >&2

--- a/bin/install
+++ b/bin/install
@@ -17,7 +17,6 @@ get_platform () {
             ;;
         *)
             echo "Platform '${platform}' not supported!" >&2
-            exit 1
             ;;
     esac
 
@@ -32,7 +31,6 @@ get_arch () {
         i686|i386) arch="ia32"; ;;
         *)
             echo "Arch '$(uname -m)' not supported!" >&2
-            exit 2
             ;;
     esac
 
@@ -57,7 +55,14 @@ install_dart () {
     local version=$2
     local install_path=$3
     local platform=$(get_platform)
+    if [ "$platform"  == "" ]; then
+        exit 1
+    fi
     local arch=$(get_arch)
+    if [ "$arch"  == "" ]; then
+        exit 2
+    fi
+
     local tempdir=$(my_mktemp $platform)
     local allow_extras=0
     local major_version=$(echo $version | cut -d "." -f1)
@@ -72,6 +77,9 @@ install_dart () {
     echo "Include Extras: $allow_extras"
     echo "Major Dart Version: $major_version"
     validate_unzip
+    if [ "$?" -gt 0 ]; then
+        exit 3
+    fi
 
     if [ $major_version -lt "2" ]; then
         allow_extras=1


### PR DESCRIPTION
## Problem
There have been a couple issues reported in the past where the install script tries to unzip an empty zip file. The root cause of this issue has always been a failure in validation. Either the architecture isn't supported or the version is invalid in some way. I was attempting to use exit codes to abort the script but because these exit codes were wrapped in functions running inside sub-shells, those exit codes didn't propagate to the parent shell process.

Also it looks like the new Apple architecture wasn't supported ("arm64").

## Solution
Change how errors are propagated. Either by checking for an empty platform or architecture. In the case of the unzip command I can check `$?`. These should now appropriately abort the script and display the relevant error message to the user.

After looking at this page https://dart.dev/tools/sdk/archive , it seems like `arm64` is just another x64 so I added it to that group.

@jerold I think this should fix your issue. I don't have an arm64 to test with but it seemed to behave correctly when I stubbed in a fake architecture "lmao64" instead of calling `uname -m`. You should be able to just go into `~/.asdf/pluging/dart` and `git fetch && git checkout add-support-for-apple-arm64`. Then try to install 2.7.0 again.