### PR TITLE
Fix file watcher

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -3,6 +3,13 @@
 ## tools/dart_version_watcher.sh
 This tool provides an automated way to keep your Dart SDK path up-to-date.
 
+This tool works by creating a file watcher on ${HOME}/.tool_versions (where your
+global versions are tracked) and sym-linking a directory when that changes. I
+have attempted to make it idempotent by having the script look for other running
+instances before setting up the file watcher. If you see multiple instances of
+this script running or multiple fswatch processes running, please try to
+determine how you did that and file and issue. Thanks!
+
 **Dependecies**
 
 [fswatch](https://github.com/emcrisostomo/fswatch) - fswatch is a multi-platform file system notifier.
@@ -10,9 +17,4 @@ This tool provides an automated way to keep your Dart SDK path up-to-date.
 **Installation**
 
 Add the script to your `.bashrc`|`.zshrc`|`config.fish` to guarantee it runs on startup.
-
-**Example**
-
-echo "bash ${HOME}/.asdf/plugins/dart/tools/dart_version_watcher.sh" >> ${HOME}/.zshrc
-
 

--- a/tools/dart_version_watcher.sh
+++ b/tools/dart_version_watcher.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 set -o nounset                              # Treat unset variables as an error
 
-fs_watch_instances=$(ps | grep "fswatch ${HOME}/.tool-versions" | wc -l | tr -d "[:blank:]")
-
 # verify we only have one watcher running
-[ "$fs_watch_instances" -gt "1" ] && exit
+pidof -o %PPID -x $0 >/dev/null && exit 1
 
-fswatch ${HOME}/.tool-versions | while read event
+fswatch -m poll_monitor ${HOME}/.tool-versions | while read event
 do
     rm -f ${HOME}/.asdf_dart_sdk && ln -s $(asdf where dart)/dart-sdk ${HOME}/.asdf_dart_sdk
 done &


### PR DESCRIPTION
** Problem **
My initial guard against setting up multiple `fswatch` instance ran into some race conditions.

** Solution **
Use `pidof` instead of grepping through ps looking for an existing process.

** Caveats **
This can still run multiple instance if the script is started from different directories. As an example:
- Starting it from within the `tools` directory (`tools/dart_version_watcher.sh`)
- Starting it from home (`$HOME/.asdf/plugins/dart/tools/dart_version_watcher.sh`)

I don't know why anyone would do that so I'm not going to worry about it for now.