### PR TITLE
Removing the arm64 download for now

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -27,8 +27,7 @@ get_arch () {
     local arch=""
 
     case "$(uname -m)" in
-        arm64) arch="arm64"; ;;
-        x86_64|amd64) arch="x64"; ;;
+        x86_64|amd64|arm64) arch="x64"; ;;
         i686|i386) arch="ia32"; ;;
         *)
             echo "Arch '$(uname -m)' not supported!" >&2
@@ -36,24 +35,6 @@ get_arch () {
     esac
 
     echo -n $arch
-}
-
-# Dart has support for MacOS arm starting with 2.14.1 . This function will echo
-# the desired version and the first version that supports arm. These dot separated
-# versions will then be passed to sort and the lowest version will be first in the
-# list. If the lowest version is 2.14.1, then we can use the M1 binary. If it's not
-# we have to use the x64 version.
-fix_macos () {
-    local version="$1"
-    local armversion="2.14.1"
-    local lowest=`echo "$armversion
-$version" | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -g | head -n1`
-    if [ "$lowest" == "$armversion" ]; then
-        echo -n "arm64"
-        return
-    fi
-    echo -n "x64"
-    return
 }
 
 my_mktemp () {
@@ -73,9 +54,6 @@ install_dart () {
     local install_type=$1
     local version=$2
     local install_path=$3
-    local major_version=$(echo $version | cut -d "." -f1)
-    local minor_version=$(echo $version | cut -d "." -f2)
-    local patch_version=$(echo $version | cut -d "." -f3)
     local platform=$(get_platform)
     if [ "$platform"  == "" ]; then
         exit 1
@@ -85,13 +63,9 @@ install_dart () {
         exit 2
     fi
 
-    # fix arch if pulling a version of dart less than 2.14.1
-    if [ "$arch" == "arm64" ] && [ "$platform" == "darwin" ]; then
-        arch=$(fix_macos "$version")
-    fi
-
     local tempdir=$(my_mktemp $platform)
     local allow_extras=0
+    local major_version=$(echo $version | cut -d "." -f1)
     # supported channels are "stable", "beta" and "dev"
     local channel="stable"
 
@@ -102,8 +76,6 @@ install_dart () {
     echo "Downloading to temp directory $tempdir"
     echo "Include Extras: $allow_extras"
     echo "Major Dart Version: $major_version"
-    echo "Minor Dart Version: $minor_version"
-    echo "Patch Dart Version: $patch_version"
     validate_unzip
     if [ "$?" -gt 0 ]; then
         exit 3


### PR DESCRIPTION
There has been a handful of reports that this isn't able to download
pre-arm64 versions (<2.14.1). I tried to add a version parser that would
switch back to x64 if the version is lower, but according to users that
didn't seem to work either. I don't know the benefits of downloading the
arm64 version at this time so I'm going to revert the change.