### PR TITLE
Add arm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ inside the `tools/` directory.
 - `content_shell` (Dart 1 exclusive)
 - `dartium` (Dart 1 exclusive)
 
+## Changelog
+### July 27 2022
+The plugin has been updated to properly download arm versions of the Dart SDK.
+If you're unsure if you're using the arm version you can `asdf uninstall dart <version>` and then re-install.
+
 ## Contributing
 
 Feel free to create an issue or pull request if you find a bug.

--- a/bin/install
+++ b/bin/install
@@ -27,7 +27,8 @@ get_arch () {
     local arch=""
 
     case "$(uname -m)" in
-        x86_64|amd64|arm64) arch="x64"; ;;
+        x86_64|amd64) arch="x64"; ;;
+        arm64) arch="arm"; ;;
         i686|i386) arch="ia32"; ;;
         *)
             echo "Arch '$(uname -m)' not supported!" >&2


### PR DESCRIPTION
This change re-introduces the arm64 case for architecture. This was a tricky feature to support because Dart added this support in 2.14.0 but older versions did not have arm binaries. This meant that pre-2.14.0 versions would still need to download x64 versions of the SDK. This resulted in me trying to parse semver in bash and it sucked a lot. I opted to remove support for arm since Apple M1 supported the x64 version any way.

It looks like Google has back-built all the older versions of Dart though! So no special handling for different versions is necessary.