### PR TITLE
Allow for missing file watch or symlink dir

### DIFF
--- a/tools/dart_version_watcher.sh
+++ b/tools/dart_version_watcher.sh
@@ -1,14 +1,35 @@
 #!/bin/bash
 set -o nounset                              # Treat unset variables as an error
 
-fs_watch_instances=$(ps | grep "fswatch ${HOME}/.tool-versions" | wc -l | tr -d "[:blank:]")
+SYMLINK_DIR=".asdf_dart_sdk"
+TOOL_VERSIONS=".tool-versions"
+DART_SDK="dart-sdk"
+
+create_symlink () {
+  if [ ! -d "${HOME}/${SYMLINK_DIR}" ]
+    then
+      echo "No ${HOME}/${SYMLINK_DIR} dir found. Creating symlinked dart sdk dir..."
+      ln -s $(asdf where dart)/${DART_SDK} ${HOME}/${SYMLINK_DIR}
+      echo "Directory created!"
+    fi
+    echo "Version watcher is running and ${HOME}/${SYMLINK_DIR} is symlinked to $(asdf where dart)/${DART_SDK}, you're all set! You can now set the dart lib sdk path to ${HOME}/${SYMLINK_DIR} in your IDE."
+}
+
+fs_watch_instances=$(ps | grep "fswatch ${HOME}/${TOOL_VERSIONS}" | grep -cwv grep | tr -d "[:blank:]")
 
 # verify we only have one watcher running
-[ "$fs_watch_instances" -gt "1" ] && exit
+if [ "$fs_watch_instances" -ge "1" ]
+then
+  echo "Version watcher is already running. Checking for ${HOME}/${SYMLINK_DIR} dir..."
+  create_symlink
+  exit
+fi
 
-fswatch ${HOME}/.tool-versions | while read event
+echo "Version watcher created! Checking for already existing ${HOME}/${SYMLINK_DIR} symlink"
+
+create_symlink
+
+fswatch ${HOME}/${TOOL_VERSIONS} | while read event
 do
-    rm -f ${HOME}/.asdf_dart_sdk && ln -s $(asdf where dart)/dart-sdk ${HOME}/.asdf_dart_sdk
+    rm -f ${HOME}/${SYMLINK_DIR} && ln -s $(asdf where dart)/${DART_SDK} ${HOME}/${SYMLINK_DIR}
 done &
-
-


### PR DESCRIPTION
### Description
I ran into a subtle issue when setting up my new computer where the `.asdf_dart_sdk` dir wasn't created after running the `dart_version_watcher.sh` script _after_ installing and activating Dart. This is because the script doesn't initially create the symlink if one isn't created already.

After this change, on any run of this script, the symlink dir should be created if it wasn't already, and the file watcher should be running. I've also included some output that could be helpful and informative to the user.

I also fixed a subtle bug around word counting the output of `ps` - the the `grep` command that we are running was included in the line count, causing an off by one error. In practice, this didn't cause issues because we were using `-gt` and not `-ge`:
![Screenshot 2023-05-01 at 1 15 54 PM](https://user-images.githubusercontent.com/12497362/235513967-0451e16b-63d6-4f50-aa3b-da1f4db91457.png)

### QA steps:
* Run this script with:
  * [ ] No symlink, and no file watcher running
  * [ ] No symlink, and a file watcher already running
  * [ ] symlink, but no file watcher running
  * [ ] symlink, and a file watcher already running
In all cases, the end state should be a successful script exit code, some informative and correct output, and both the symlink and the file watcher created.