### PR TITLE
Remove top "dart-sdk" directory

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -130,12 +130,17 @@ install_dart () {
     fi
 
     echo "Unzipping Dart SDK to $install_path..."
+    # Remove top level directory from zip
+    ln -s . dart-sdk
     if command -v unzip &> /dev/null
     then
         unzip -d "$install_path" "$tempdir/sdk.zip" > /dev/null 2>&1
     else
         7z x "$tempdir/sdk.zip" -o"$install_path" > /dev/null 2>&1
     fi
+
+    # Remove symlink
+    rm dart-sdk
 
     if [ $allow_extras -eq "1" ]; then
         echo "Unzipping Content Shell to $install_path..."

--- a/bin/install
+++ b/bin/install
@@ -131,7 +131,7 @@ install_dart () {
 
     echo "Unzipping Dart SDK to $install_path..."
     # Remove top level directory from zip
-    ln -s . dart-sdk
+    ln -s . "$install_path/dart-sdk"
     if command -v unzip &> /dev/null
     then
         unzip -d "$install_path" "$tempdir/sdk.zip" > /dev/null 2>&1
@@ -140,7 +140,7 @@ install_dart () {
     fi
 
     # Remove symlink
-    rm dart-sdk
+    rm -r "$install_path/dart-sdk"
 
     if [ $allow_extras -eq "1" ]; then
         echo "Unzipping Content Shell to $install_path..."

--- a/bin/install
+++ b/bin/install
@@ -140,7 +140,7 @@ install_dart () {
     fi
 
     # Remove symlink
-    rm -r "$install_path/dart-sdk"
+    rm -f "$install_path/dart-sdk"
 
     if [ $allow_extras -eq "1" ]; then
         echo "Unzipping Content Shell to $install_path..."

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -3,4 +3,4 @@
 CONTENT_SHELL_DIR=$(ls $ASDF_INSTALL_PATH | grep "drt-")
 DARTIUM_DIR=$(ls $ASDF_INSTALL_PATH | grep "dartium-")
 
-echo -n "dart-sdk/bin $CONTENT_SHELL_DIR $DARTIUM_DIR"
+echo -n "bin dart-sdk/bin $CONTENT_SHELL_DIR $DARTIUM_DIR"


### PR DESCRIPTION
# Issue
I was dealing with `dart.sdkPaths` on vscode, the documentation states: 
> An array of paths that either directly point to a Dart SDK or the parent directory of multiple Dart SDKs that can be used for fast SDK switching. 

The current solution is adding each sdk by hand, using `~/.asdf/installs/dart/x.x.x` or `~/.asdf/installs/dart/x.x.x/dart-sdk`, that's kinda annoying.


Now we can set `dart.sdkPaths` with `~/.asdf/installs/dart`, and each version is detected.