### PR TITLE
Remove top directory unzip docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Check the [asdf](https://github.com/asdf-vm/asdf) README for instructions on how
 
 ## Customization
 The default behavior for this plugin used to include `dev` and `beta` versions
-when listing all the versions. This got really noisy and interfered with 
+when listing all the versions. This got really noisy and interfered with
 `asdf install dart latest` installing the latest stable version. If you want
 to re-enable these channels you can set these environment variables.
 ```
@@ -58,6 +58,30 @@ inside the `tools/` directory.
 - `and many more...`
 - `content_shell` (Dart 1 exclusive)
 - `dartium` (Dart 1 exclusive)
+
+## Working with multiple SDKs
+If you're using this plugin it's probably because you're using multiple
+versions of the Dart SDK. This means you also want to be able to use different
+versions of the language server. This is easy enough in Vim/Neovim by getting
+the language server path by running `asdf where dart`. In VSCode, you'll
+probably want to use the `dart.sdkPaths` setting. This will allow you to add a
+path where your SDKs are located and then switch them on the fly. An example
+value for this setting is `<an absolute path to your asdf
+folder>/installs/dart`. If you hover over the Dart Syntax Switcher in the
+bottom right of the editor you should see a way to change which SDK you want to
+use.
+
+<img width="346" alt="A screenshot showing a popup menu when hovering over the
+syntax selector in VSCode. There is a label that shows the current Dart version
+and a button that says 'change'."
+src="https://github.com/PatOConnor43/asdf-dart/assets/6657525/c82b9974-a121-4fb8-b35a-6d590bf0db7c">
+
+*IMPORTANT NOTE: If there are versions of the SDK that are installed, but don't
+show up in the menu, you should be able to uninstall and re-install those
+versions. This is due to a path change that was necessary to facilitate this
+feature.*
+
+Shoutout to @Rapougnac for bringing this up!
 
 ## Contributing
 

--- a/bin/install
+++ b/bin/install
@@ -130,12 +130,17 @@ install_dart () {
     fi
 
     echo "Unzipping Dart SDK to $install_path..."
+    # Remove top level directory from zip
+    ln -s . dart-sdk
     if command -v unzip &> /dev/null
     then
         unzip -d "$install_path" "$tempdir/sdk.zip" > /dev/null 2>&1
     else
         7z x "$tempdir/sdk.zip" -o"$install_path" > /dev/null 2>&1
     fi
+
+    # Remove symlink
+    rm dart-sdk
 
     if [ $allow_extras -eq "1" ]; then
         echo "Unzipping Content Shell to $install_path..."

--- a/bin/install
+++ b/bin/install
@@ -131,7 +131,7 @@ install_dart () {
 
     echo "Unzipping Dart SDK to $install_path..."
     # Remove top level directory from zip
-    ln -s . dart-sdk
+    ln -s . "$install_path/dart-sdk"
     if command -v unzip &> /dev/null
     then
         unzip -d "$install_path" "$tempdir/sdk.zip" > /dev/null 2>&1
@@ -140,7 +140,7 @@ install_dart () {
     fi
 
     # Remove symlink
-    rm dart-sdk
+    rm -r "$install_path/dart-sdk"
 
     if [ $allow_extras -eq "1" ]; then
         echo "Unzipping Content Shell to $install_path..."

--- a/bin/install
+++ b/bin/install
@@ -140,7 +140,7 @@ install_dart () {
     fi
 
     # Remove symlink
-    rm -r "$install_path/dart-sdk"
+    rm -f "$install_path/dart-sdk"
 
     if [ $allow_extras -eq "1" ]; then
         echo "Unzipping Content Shell to $install_path..."

--- a/bin/install
+++ b/bin/install
@@ -130,7 +130,7 @@ install_dart () {
     fi
 
     echo "Unzipping Dart SDK to $install_path..."
-    # Remove top level directory from zip
+    # Create symlink to redirect un-zipping to this directory
     ln -s . "$install_path/dart-sdk"
     if command -v unzip &> /dev/null
     then
@@ -139,7 +139,7 @@ install_dart () {
         7z x "$tempdir/sdk.zip" -o"$install_path" > /dev/null 2>&1
     fi
 
-    # Remove symlink
+    # Clean up symlink
     rm -f "$install_path/dart-sdk"
 
     if [ $allow_extras -eq "1" ]; then

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -3,4 +3,4 @@
 CONTENT_SHELL_DIR=$(ls $ASDF_INSTALL_PATH | grep "drt-")
 DARTIUM_DIR=$(ls $ASDF_INSTALL_PATH | grep "dartium-")
 
-echo -n "dart-sdk/bin $CONTENT_SHELL_DIR $DARTIUM_DIR"
+echo -n "bin dart-sdk/bin $CONTENT_SHELL_DIR $DARTIUM_DIR"


### PR DESCRIPTION
Add support and docs for `dart.sdkPaths`. I had an initial worry about this because I wasn't sure if changing where binaries were saved would be a breaking change. After thinking about it, I think this should be fine because people should probably be using `asdf which dart` or `asdf where dart` to find what they're looking for. Thanks @Rapougnac !