### PR TITLE
Document improved vscode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ ASDF_DART_ENABLE_DEV=true
 ```
 These environment variables will ensure only the base versions are included.
 
-## Installation differences between Dart 1 and Dart 2
-
-All Dart 1 versions come with corresponding versions of `content_shell` and `dartium`. Since Dart 2 doesn't use these tools, they aren't included. For more information on tooling differences, check out [the docs](https://webdev.dartlang.org/dart-2).
-
 ## Using in your favorite IDE/Editor
 
 Dart plugins for IntelliJ, VS Code, etc., typically need you to provide a path where the Dart SDK is installed.

--- a/README.md
+++ b/README.md
@@ -33,15 +33,30 @@ These environment variables will ensure only the base versions are included.
 All Dart 1 versions come with corresponding versions of `content_shell` and `dartium`. Since Dart 2 doesn't use these tools, they aren't included. For more information on tooling differences, check out [the docs](https://webdev.dartlang.org/dart-2).
 
 ## Using in your favorite IDE/Editor
+
 Dart plugins for IntelliJ, VS Code, etc., typically need you to provide a path where the Dart SDK is installed.
 Using asdf installs Dart in a consistent place, but may be confusing if you don't know where that is.
 The install location can be found by running `asdf where dart`, which should be `$HOME/.asdf/installs/dart/VERSION`
-Continuously updating this path can get annoying between upgrades or if you're doing work between Dart 1 and 2.
-Because of this I added a script to this repo (`tools/dart_version_watcher.sh`) that will create a file watcher
-for any time your global versions change and then update a symlink that points to the current version.
-This means you can point your IDE at `${HOME}/.asdf_dart_sdk` and anytime you change versions, this file
-will point to the most recent version. If you're interested check the [install instructions](./tools/README.md)
-inside the `tools/` directory.
+
+### VSCode
+
+[Dart Code](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code) can be configured to use the active asdf version using the following `settings.json` configuration
+
+```json
+{
+  "dart.sdkPaths": ["~/.asdf/installs/dart/"],
+  "dart.getDartSdkCommand": {
+    "executable": "asdf",
+    "args": ["where", "dart"]
+  },
+}
+```
+
+### Other IDE/Editor
+
+`tools/dart_version_watcher.sh` that will create a file watcher for any time your global versions change and then update a symlink that points
+to the current version. This means you can point your IDE at `${HOME}/.asdf_dart_sdk` and anytime you change versions, this file will point to
+the most recent version. If you're interested check the [install instructions](./tools/README.md) inside the `tools/` directory.
 
 ## Included Shims
 


### PR DESCRIPTION
The dart vscode extension has added the ability to configure the dart sdk [path via executable](https://github.com/Dart-Code/Dart-Code/pull/5377)

This PR updates the README documentation to use this new configuration concept which has the major benefit in supporting local `.tool-version` files over the global-only `dart_version_watcher.sh` approach

Also removed the legacy dart 1 documentation since dart 1 is so old at this point