### PR TITLE
macos tahoe seems to have changed the behavior for ln/unzip

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -130,17 +130,16 @@ install_dart () {
     fi
 
     echo "Unzipping Dart SDK to $install_path..."
-    # Create symlink to redirect un-zipping to this directory
-    ln -s . "$install_path/dart-sdk"
     if command -v unzip &> /dev/null
     then
         unzip -d "$install_path" "$tempdir/sdk.zip" > /dev/null 2>&1
     else
         7z x "$tempdir/sdk.zip" -o"$install_path" > /dev/null 2>&1
     fi
+    mv "$install_path/dart-sdk"/* "$install_path/"
 
     # Clean up symlink
-    rm -f "$install_path/dart-sdk"
+    rm -rf "$install_path/dart-sdk"
 
     if [ $allow_extras -eq "1" ]; then
         echo "Unzipping Content Shell to $install_path..."


### PR DESCRIPTION
## Problem

Previously we were relying on the ability to unzip the dart sdk into a symbolically linked directory. 

##Solution

That doesn't work anymore  so we're changing the approach to not use ln at all.